### PR TITLE
AMGUI-2 Add support of Jpeg images

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -81,8 +81,9 @@ static void open_dialog (GtkWidget *button, gpointer window)
     dialog = GTK_WIDGET (gtk_file_chooser_native_new ("Choose a file:", GTK_WINDOW (window), GTK_FILE_CHOOSER_ACTION_OPEN, "_Select", "_Cancel"));
 
     GtkFileFilter *filter = gtk_file_filter_new ();
-    gtk_file_filter_set_name (filter, "BMP files");
+    gtk_file_filter_set_name (filter, "BMP/JPG files");
     gtk_file_filter_add_mime_type (filter, "image/bmp");
+    gtk_file_filter_add_mime_type (filter, "image/jpeg");
     gtk_file_chooser_add_filter (GTK_FILE_CHOOSER (dialog), filter);
     gtk_widget_show_all (dialog);
 

--- a/prepare_build.sh
+++ b/prepare_build.sh
@@ -1,4 +1,5 @@
+rm -rf aquamarine &&
 git clone https://github.com/MaksymT17/aquamarine.git &&
 cd aquamarine &&
 # hash of working commit which was used in test
-git checkout 558b0e589a29b452b748f401d55f8d5c5f2e9841
+git checkout e96c385911e5172b1afdfe51fc06c44ce29cfac5


### PR DESCRIPTION
Add support for Jpeg images.
Verify with the application that JPEG can be processed.
Update the hash of the verified commit.